### PR TITLE
Fix instruction to run test and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ NOTE: To stop the capture, you can exit the process like you usually do (Eg. `Ct
 After you captured all requests you want, you just need to add the mode parameter `--mode test` to the Pythagora command.
 <br>
    ```
-   npx pythagora --script ./path/to/your/server.js --mode test
+   npx pythagora --script ./path/to/your/server.js --mode test --initScript ./path/to/your/server.js
    ```   
 
 <br><br>
@@ -85,7 +85,7 @@ Code coverage is a great metric while building automated tests as it shows us wh
 
 If you want to generate a more detailed report, you can do so by running Pythagora with `--full-code-coverage-report` flag. Eg.
    ```
-   npx pythagora --script ./path/to/your/server.js --mode test --full-code-coverage-report
+   npx pythagora --script ./path/to/your/server.js --mode test --full-code-coverage-report --initScript ./path/to/your/server.js
    ```
 You can find the code coverage report inside `pythagora_data` folder in the root of your repository. You can open the HTML view of the report by opening `pythagora_data/code_coverage_report/lcov-report/index.html`.
 


### PR DESCRIPTION
Fix instruction to run test and coverage

Result from old instruction

```
npx pythagora --script ./path/to/your/server.js --mode test
Pythagora is unable to check dependencies. Continuing and hoping you have Express and Mongoose installed...

Please provide the script that you use to start your Node.js app by adding --initScript <relative path to the file you would usually run to start your app>.

Eg. --initScript ./app.js


=============================== Coverage summary ===============================
Statements   : Unknown% ( 0/0 )
Branches     : Unknown% ( 0/0 )
Functions    : Unknown% ( 0/0 )
Lines        : Unknown% ( 0/0 )
================================================================================
```