### PR TITLE
Bugfix - Spaces in Path

### DIFF
--- a/src/utils/getArgs.js
+++ b/src/utils/getArgs.js
@@ -9,6 +9,13 @@ let args = {};
 for (let i = 0; i < argArray.length; i++) {
     const arg = argArray[i].trim().split(' ');
 
+	//Rejoin any arguments that have spaces in them beyond arg[0],
+	//i.e, directories with spaces in their names
+	if(arg.length > 2){ 
+		arg[1] = arg.slice(1).join(' ');
+		arg.splice(2); //Removes the extra arguments
+	}
+
     if (!arg[0]) continue;
     args[arg[0].replace(/-/g, '_')] = arg.length > 2 ? arg.slice(1) : (arg[1] || true);
 }


### PR DESCRIPTION
Fixed a bug here in which `getArgs` would fail in the case that Pythagora was being utilized from a subdirectory that contains a space in its path.

See the error below:

![PythagoraBug](https://github.com/Pythagora-io/pythagora/assets/71980770/7d09b6dd-a862-4bed-a3d6-fc49322efa2e)
